### PR TITLE
Snapcraft

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,18 @@
+name: keyhole
+version: git
+summary: Peek at your MongoDB Clusters like a Pro with Keyhole
+description: |
+  Keyhole is a performance analytics tool, written in GO (Golang), to collect stats from MongoDB instances and to analyze performance of a MongoDB cluster. Golang was chosen to eliminate the needs to install an interpreter or software modules.
+confinement: classic
+base: core18
+parts:
+  keyhole:
+    plugin: go
+    go-importpath: github.com/simagix/keyhole
+    source: .
+    source-type: git
+    build-packages:
+      - gcc
+apps:
+  keyhole:
+    command: bin/keyhole

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,3 +1,4 @@
+## snapcraft config file
 name: keyhole
 version: git
 summary: Peek at your MongoDB Clusters like a Pro with Keyhole


### PR DESCRIPTION
Added snapcraft.yaml file. This will allow a snap to be built by running the "snapcraft" command (assuming snapcraft is installed on the system). This addition should not affect existing build scripts. 