### PR TITLE
support for MONGODB-AWS auth

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 require (
 	github.com/simagix/gox v0.2.0
-	go.mongodb.org/mongo-driver v1.3.7
+	go.mongodb.org/mongo-driver v1.4.2
 	golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a
 	golang.org/x/text v0.3.3
 )

--- a/mdb/mongo_client.go
+++ b/mdb/mongo_client.go
@@ -38,7 +38,7 @@ func NewMongoClient(uri string, files ...string) (*mongo.Client, error) {
 	if connString.ReplicaSet == "" && len(connString.Hosts) == 1 && strings.HasPrefix(uri, "mongodb://") {
 		opts.SetDirect(true)
 	}
-	if connString.Username == "" && connString.AuthMechanism != "MONGODB-AWS" {
+	if connString.Username == "" && connString.AuthMechanism == "" {
 		opts.Auth = nil
 	}
 	if len(files) > 0 && files[0] != "" {

--- a/mdb/mongo_client.go
+++ b/mdb/mongo_client.go
@@ -38,7 +38,7 @@ func NewMongoClient(uri string, files ...string) (*mongo.Client, error) {
 	if connString.ReplicaSet == "" && len(connString.Hosts) == 1 && strings.HasPrefix(uri, "mongodb://") {
 		opts.SetDirect(true)
 	}
-	if connString.Username == "" {
+	if connString.Username == "" && connString.AuthMechanism != "MONGODB-AWS" {
 		opts.Auth = nil
 	}
 	if len(files) > 0 && files[0] != "" {


### PR DESCRIPTION
Update mongo driver to support MONGODB-AWS auth, also don't set `opts.Auth` to nil if using MONGODB-AWS and no username/pass (can auth using env vars, EC2/ECS credentials)