### PR TITLE
add -compare feature

### DIFF
--- a/comparison.md
+++ b/comparison.md
@@ -1,10 +1,10 @@
 # Clusters Comparison
-The `-compare` feature compares two MongoDB clusters, either from connection strings or output files of `-allinfo`, and display results.  This feature provides a way of quick sanity check after migrating to a MongoDB cluster to Atlas.
+The `-compare` feature compares two MongoDB clusters, either from connection strings or output files of `-allinfo`, and display results.  This feature provides a way of quick sanity check after migrating a MongoDB cluster to Atlas.
 
 ## Usage
 
 ```bash
-keyhole -compare <source_connection_string> <target_connection_string>
+keyhole [-nocolor] -compare <source_connection_string> <target_connection_string>
 ```
 
 For example:
@@ -21,39 +21,40 @@ keyhole -compare source-allinfo-stats.bson.gz target-allinfo-stats.bson.gz
 
 ## Example Outputs
 
+The results are in red ink if the numbers between the source and the target are different.  If `-nocolor` flag is used, Keyhole mark it with a **≠** instead.
+
 ```bash
-2020/12/31 22:15:13 
-=== Comparison Results (source vs. target) ===
-2020/12/31 22:15:13 Number of Databases:                   4               5
-2020/12/31 22:15:13 Database keyhole
-2020/12/31 22:15:13  ├─Number of Collections:              8               8
-2020/12/31 22:15:13  ├─Number of Indexes:                 17              17 (all shards)
-2020/12/31 22:15:13  ├─Number of Objects:              3,160           3,160
-2020/12/31 22:15:13  ├─Total Data Size:                3.0MB           3.0MB
-2020/12/31 22:15:13  ├─Average Data Size:                989             989
-2020/12/31 22:15:13  └─Number of indexes
-2020/12/31 22:15:13    ├─keyhole.dealers:                  1               1
-2020/12/31 22:15:13    ├─keyhole.employees:                1               1
-2020/12/31 22:15:13    ├─keyhole.favorites:                1               1
-2020/12/31 22:15:13    ├─keyhole.lookups:                  1               1
-2020/12/31 22:15:13    ├─keyhole.models:                   1               1
-2020/12/31 22:15:13    ├─keyhole.numbers:                  5               5
-2020/12/31 22:15:13    ├─keyhole.robots:                   1               1
-2020/12/31 22:15:13    ├─keyhole.vehicles:                 6               6
-2020/12/31 22:15:13 Database maobi
-2020/12/31 22:15:13  ├─Number of Collections:              8               8
-2020/12/31 22:15:13  ├─Number of Indexes:                 23              17 (all shards)
-2020/12/31 22:15:13  ├─Number of Objects:             21,139          21,139
-2020/12/31 22:15:13  ├─Total Data Size:               29.3MB          29.3MB
-2020/12/31 22:15:13  ├─Average Data Size:              1.4KB           1.4KB
-2020/12/31 22:15:13  └─Number of indexes
-2020/12/31 22:15:13    ├─maobi.dealers:                    1               1
-2020/12/31 22:15:13    ├─maobi.employees:                  1               1
-2020/12/31 22:15:13    ├─maobi.favorites:                  1               1
-2020/12/31 22:15:13    ├─maobi.lookups:                    1               1
-2020/12/31 22:15:13    ├─maobi.models:                     1               1
-2020/12/31 22:15:13    ├─maobi.numbers:                    5               5
-2020/12/31 22:15:13    ├─maobi.robots:                     1               1
-2020/12/31 22:15:13    ├─maobi.vehicles:                   6               6
-2020/12/31 22:15:13 bson data written to ./out/hostname-compare.bson.gz
+2021/01/02 15:39:44 === Comparison Results (source vs. target) ===
+2021/01/02 15:39:44 Number of Databases:                   4               4
+2021/01/02 15:39:44 Database keyhole
+2021/01/02 15:39:44  ├─Number of Collections:              8               8
+2021/01/02 15:39:44  ├─Number of Indexes:                 17              17 (all shards)
+2021/01/02 15:39:44  ├─Number of Objects:              3,160           3,160
+2021/01/02 15:39:44  ├─Total Data Size:                3.0MB           3.0MB
+2021/01/02 15:39:44  ├─Average Data Size:                989             989
+2021/01/02 15:39:44  └─Number of indexes:
+2021/01/02 15:39:44    ├─keyhole.dealers:                  1               1
+2021/01/02 15:39:44    ├─keyhole.employees:                1               1
+2021/01/02 15:39:44    ├─keyhole.favorites:                1               1
+2021/01/02 15:39:44    ├─keyhole.lookups:                  1               1
+2021/01/02 15:39:44    ├─keyhole.models:                   1               1
+2021/01/02 15:39:44    ├─keyhole.numbers:                  5               5
+2021/01/02 15:39:44    ├─keyhole.robots:                   1               1
+2021/01/02 15:39:44    ├─keyhole.vehicles:                 6               6
+2021/01/02 15:39:44 Database maobi
+2021/01/02 15:39:44  ├─Number of Collections:              8               8
+2021/01/02 15:39:44  ├─Number of Indexes:                 18 ≠            17 (all shards)
+2021/01/02 15:39:44  ├─Number of Objects:            401,149 ≠       401,147
+2021/01/02 15:39:44  ├─Total Data Size:              584.5MB ≠       584.5MB
+2021/01/02 15:39:44  ├─Average Data Size:              1.5KB ≠         1.5KB
+2021/01/02 15:39:44  └─Number of indexes:
+2021/01/02 15:39:44    ├─oplog.dealers:                    1               1
+2021/01/02 15:39:44    ├─oplog.employees:                  1               1
+2021/01/02 15:39:44    ├─oplog.favorites:                  1               1
+2021/01/02 15:39:44    ├─oplog.lookups:                    1               1
+2021/01/02 15:39:44    ├─oplog.models:                     1               1
+2021/01/02 15:39:44    ├─oplog.numbers:                    5               5
+2021/01/02 15:39:44    ├─oplog.robots:                     1               1
+2021/01/02 15:39:44    ├─oplog.vehicles:                   6               6
+2021/01/02 15:39:44 bson data written to ./out/hostname-compare.bson.gz
 ```

--- a/keyhole.go
+++ b/keyhole.go
@@ -109,6 +109,7 @@ func Run(fullVersion string) {
 		return
 	} else if *compare {
 		comp := NewComparison(fullVersion)
+		comp.SetNoColor(*nocolor)
 		comp.SetTLSCAFile(*tlsCAFile)
 		comp.SetTLSCertificateKeyFile(*tlsCertificateKeyFile)
 		comp.SetVerbose(*verbose)

--- a/mdb/index_stats.go
+++ b/mdb/index_stats.go
@@ -367,8 +367,8 @@ func (ix *IndexStats) PrintIndexesOf(databases []Database) {
 			buffer.WriteString(ns)
 			buffer.WriteString(":\n")
 			for _, o := range coll.Indexes {
-				font := codeDefault
-				tailCode := codeDefault
+				font := CodeDefault
+				tailCode := CodeDefault
 				if ix.nocolor {
 					font = ""
 					tailCode = ""
@@ -379,12 +379,12 @@ func (ix *IndexStats) PrintIndexesOf(databases []Database) {
 					buffer.WriteString(fmt.Sprintf("%v* %v%v", font, o.KeyString, tailCode))
 				} else if o.IsDupped == true {
 					if ix.nocolor == false {
-						font = codeRed
+						font = CodeRed
 					}
 					buffer.WriteString(fmt.Sprintf("%vx %v%v", font, o.KeyString, tailCode))
 				} else if o.TotalOps == 0 {
 					if ix.nocolor == false {
-						font = codeBlue
+						font = CodeBlue
 					}
 					buffer.WriteString(fmt.Sprintf("%v? %v%v", font, o.KeyString, tailCode))
 				} else {

--- a/mdb/logger.go
+++ b/mdb/logger.go
@@ -42,7 +42,7 @@ func (p *Logger) Add(message string) {
 // Warn adds an warning message
 func (p *Logger) Warn(message string) {
 	p.Warnings = append(p.Warnings, message)
-	fmt.Println(codeRed, "*", message, codeDefault)
+	fmt.Println(CodeRed, "*", message, CodeDefault)
 }
 
 // Log adds and prints a message
@@ -65,7 +65,7 @@ func (p *Logger) Print() string {
 			if p.nocolor {
 				strs = append(strs, warning)
 			} else {
-				strs = append(strs, fmt.Sprintf(`%v%v%v`, codeRed, warning, codeDefault))
+				strs = append(strs, fmt.Sprintf(`%v%v%v`, CodeRed, warning, CodeDefault))
 			}
 		}
 		strs = append(strs, "")

--- a/mdb/loginfo.go
+++ b/mdb/loginfo.go
@@ -368,9 +368,9 @@ func (li *LogInfo) Print() {
 // printLogsSummary prints loginfo summary
 func (li *LogInfo) printLogsSummary() string {
 	var maxSize = 10
-	red := codeRed
-	green := codeGreen
-	tail := codeDefault
+	red := CodeRed
+	green := CodeGreen
+	tail := CodeDefault
 	if li.silent == true {
 		red = ""
 		green = ""

--- a/mdb/utils.go
+++ b/mdb/utils.go
@@ -11,11 +11,20 @@ import (
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
-var codeDefault = "\x1b[0m"
-var codeRed = "\x1b[31;1m"
-var codeGreen = "\x1b[32;1m"
-var codeYellow = "\x1b[33;1m"
-var codeBlue = "\x1b[34;1m"
+// CodeDefault shows default color
+var CodeDefault = "\x1b[0m"
+
+// CodeRed shows red color
+var CodeRed = "\x1b[31;1m"
+
+// CodeGreen shows green color
+var CodeGreen = "\x1b[32;1m"
+
+// CodeYellow shows yellow color
+var CodeYellow = "\x1b[33;1m"
+
+// CodeBlue shows blue color
+var CodeBlue = "\x1b[34;1m"
 
 // ChartDataPoint has chart data points key/value
 type ChartDataPoint struct {


### PR DESCRIPTION
The `-compare` feature compares two MongoDB clusters, either from connection strings or output files of `-allinfo`, and display results.  This feature provides a way of quick sanity check after migrating a MongoDB cluster to Atlas.
