### PR TITLE
Avoid collect index for system collections

### DIFF
--- a/mdb/index_stats.go
+++ b/mdb/index_stats.go
@@ -200,6 +200,11 @@ func (ix *IndexStats) GetIndexesFromCollection(client *mongo.Client, collection 
 	db := collection.Database().Name()
 	ix.Logger.Debugf(`GetIndexesFromCollection from %v.%v`, db, collection.Name())
 
+	if strings.HasPrefix(collection.Name(), "system.") {
+		ix.Logger.Debug("skip ", collection.Name())
+		return list, nil
+	}
+	
 	var indexStats = []IndexUsage{}
 	if scur, err = collection.Aggregate(ctx, pipeline); err != nil {
 		ix.Logger.Error(err)


### PR DESCRIPTION
Update GetIndexesFromCollection in order to not collect system collections (e.g. profiler)