### PR TITLE
Add support for more metrics in Keyhole including Reslen.

### DIFF
--- a/mdb/loginfo.go
+++ b/mdb/loginfo.go
@@ -349,7 +349,7 @@ func (li *LogInfo) OutputBSON() (string, []byte, error) {
 	}
 	re := regexp.MustCompile(`\r?\n`)
 	// output tsv file
-	lines := []string{fmt.Sprintf("%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v", "Row", "Category", "Avg Time", "Max Time", "Count", "Total Time", "Total KeysExamined", "Total DocsExamined", "Total NReturned", "Total Reslen", "Total Yields", "Namespace", "COLLSCAN", "Index(es) Used", "Query Pattern")}
+	lines := []string{fmt.Sprintf("%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v", "Row", "Category", "Avg Time", "Max Time", "Count", "Total Time", "Total KeysExamined", "Total DocsExamined", "Total NReturned", "Total Reslen", "Namespace", "COLLSCAN", "Index(es) Used", "Query Pattern")}
 	for i, doc := range li.OpPatterns {
 		avgMilli := float64(doc.TotalMilli) / float64(doc.Count)
 		lines = append(lines, fmt.Sprintf("%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v", i+1, doc.Command, gox.MilliToTimeString(avgMilli), doc.MaxMilli, doc.Count,

--- a/mdb/logv2_parser.go
+++ b/mdb/logv2_parser.go
@@ -17,11 +17,22 @@ type Logv2 struct {
 	Attributes struct {
 		Command            map[string]interface{} `json:"command" bson:"command"`
 		Milli              int                    `json:"durationMillis" bson:"durationMillis"`
+		KeysExamined       int                    `json:"keysExamined" bson:"keysExamined"`
+		DocsExamined       int                    `json:"docsExamined" bson:"docsExamined"`
+		NReturned          int                    `json:"nreturned" bson:"nreturned"`
+		ResultLen          int                    `json:"reslen" bson:"reslen"`
+		Yields             int                    `json:"numYields" bson:"numYields"`
 		NS                 string                 `json:"ns" bson:"ns"`
 		OriginatingCommand map[string]interface{} `json:"originatingCommand" bson:"originatingCommand"`
 		PlanSummary        string                 `json:"planSummary" bson:"planSummary"`
 		Type               string                 `json:"type" bson:"type"`
 	} `json:"attr" bson:"attr"`
+	Storage struct {
+		Data struct {
+			BytesRead         int `json:"bytesRead" bson:"bytesRead"`
+			TimeReadingMicros int `json:"timeReadingMicros" bson:"timeReadingMicros"`
+		} `json:"data" bson:"data"`
+	} `json:"storage" bson:"storage"`
 	Component string            `json:"c" bson:"c"`
 	ID        int               `json:"id" bson:"id"`
 	Message   string            `json:"msg" bson:"msg"`
@@ -60,7 +71,16 @@ func (li *LogInfo) ParseLogv2(str string) (LogStats, error) {
 	if c != "COMMAND" && c != "QUERY" && c != "WRITE" {
 		return stat, errors.New("unsupported command")
 	}
+
 	stat.milli = doc.Attributes.Milli
+	stat.keysExamined = doc.Attributes.KeysExamined
+	stat.docsExamined = doc.Attributes.DocsExamined
+	stat.nreturned = doc.Attributes.NReturned
+	stat.reslen = doc.Attributes.ResultLen
+	stat.yields = doc.Attributes.Yields
+	stat.storageBytesRead = doc.Storage.Data.BytesRead
+	stat.storageTimeReadingMicro = doc.Storage.Data.TimeReadingMicros
+
 	if doc.Attributes.NS == "" {
 		return stat, errors.New("no namespace found")
 	}


### PR DESCRIPTION
New fields are: Reslen KeysExamined, DocsExamined, and NReturned

These fields are available from the tsv file which can, of course, be
imported into a spreadsheet application for further analysis.

Fixes #80.