### PR TITLE
Attempt to fix snap --web option

### DIFF
--- a/contrib/snapcraft/build-snap.sh
+++ b/contrib/snapcraft/build-snap.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 cp -r ./snap ../../
 cd ../../
-snapcraft
+snapcraft "$@"

--- a/contrib/snapcraft/snap/snapcraft.yaml
+++ b/contrib/snapcraft/snap/snapcraft.yaml
@@ -5,18 +5,21 @@ summary: Peek at your MongoDB Clusters like a Pro with Keyhole
 description: |
   Keyhole is a performance analytics tool, written in GO (Golang), to collect stats from MongoDB instances and to analyze performance of a MongoDB cluster. Golang was chosen to eliminate the needs to install an interpreter or software modules.
 confinement: strict
-base: core18
+base: core20
 parts:
   keyhole:
     plugin: go
-    go-importpath: github.com/simagix/keyhole
-    source: .
+    source: https://github.com/simagix/keyhole
     source-type: git
     build-packages:
       - gcc
+    override-build: |
+        go mod tidy
+        snapcraftctl build
+
 apps:
   keyhole:
-    command: bin/keyhole
+    command: bin/main
     plugs:
       - home
       - network

--- a/contrib/snapcraft/snap/snapcraft.yaml
+++ b/contrib/snapcraft/snap/snapcraft.yaml
@@ -16,10 +16,13 @@ parts:
     override-build: |
         go mod tidy
         snapcraftctl build
+    override-prime: |
+        snapcraftctl prime
+        mv bin/main bin/keyhole
 
 apps:
   keyhole:
-    command: bin/main
+    command: bin/keyhole
     plugs:
       - home
       - network

--- a/contrib/snapcraft/snap/snapcraft.yaml
+++ b/contrib/snapcraft/snap/snapcraft.yaml
@@ -23,3 +23,4 @@ apps:
     plugs:
       - home
       - network
+      - network-bind


### PR DESCRIPTION
Please see issue #118  for context.

This pull request attempts to fix the tcp listen error when the --web option is used.

Currently I have only tested the snap locally ; it has not been published to the snap store.

@mdg-2018 Can you help with review of these fixes? As I have seen in the history, you have been involved with snap packaging of keyhole in the past.
